### PR TITLE
Fixed typo in random_get documentation

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1951,7 +1951,7 @@ The exit code returned by the process.
 Write high-quality random data into a buffer.
 This function blocks when the implementation is unable to immediately
 provide sufficient high-quality random data.
-This function may execute slowly, so when large mounts of random data are
+This function may execute slowly, so when large amounts of random data are
 required, it's advisable to use this function to seed a pseudo-random
 number generator, rather than to provide the random data directly.
 

--- a/phases/ephemeral/witx/random.witx
+++ b/phases/ephemeral/witx/random.witx
@@ -16,7 +16,7 @@
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.
   ;;;
-  ;;; This function may execute slowly, so when large mounts of random data are
+  ;;; This function may execute slowly, so when large amounts of random data are
   ;;; required, it's advisable to use this function to seed a pseudo-random
   ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "get")

--- a/phases/old/snapshot_0/docs.md
+++ b/phases/old/snapshot_0/docs.md
@@ -1959,7 +1959,7 @@ Note: This is similar to [`sched_yield`](#sched_yield) in POSIX.
 Write high-quality random data into a buffer.
 This function blocks when the implementation is unable to immediately
 provide sufficient high-quality random data.
-This function may execute slowly, so when large mounts of random data are
+This function may execute slowly, so when large amounts of random data are
 required, it's advisable to use this function to seed a pseudo-random
 number generator, rather than to provide the random data directly.
 

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -484,7 +484,7 @@
   ;;; Write high-quality random data into a buffer.
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.
-  ;;; This function may execute slowly, so when large mounts of random data are
+  ;;; This function may execute slowly, so when large amounts of random data are
   ;;; required, it's advisable to use this function to seed a pseudo-random
   ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "random_get")

--- a/phases/snapshot/docs.html
+++ b/phases/snapshot/docs.html
@@ -1211,7 +1211,7 @@ Information about a pre-opened capability.<br>Size: 8<br>Alignment: 4<h3 id="uni
 </ul>
 <hr>
 <h4 id="a-href-random_get-name-random_get-a-random_get-buf-pointeru8-buf_len-size-errno">&lt;a href=&quot;#random_get&quot; name=&quot;random_get&quot;&gt;&lt;/a&gt; <code>random_get(buf: Pointer&lt;u8&gt;, buf_len: size) -&gt; errno</code></h4>
-<p>Write high-quality random data into a buffer.<br>This function blocks when the implementation is unable to immediately<br>provide sufficient high-quality random data.<br>This function may execute slowly, so when large mounts of random data are<br>required, it&#39;s advisable to use this function to seed a pseudo-random<br>number generator, rather than to provide the random data directly.</p>
+<p>Write high-quality random data into a buffer.<br>This function blocks when the implementation is unable to immediately<br>provide sufficient high-quality random data.<br>This function may execute slowly, so when large amounts of random data are<br>required, it&#39;s advisable to use this function to seed a pseudo-random<br>number generator, rather than to provide the random data directly.</p>
 <h5 id="params">Params</h5>
 <ul>
 <li><p>&lt;a href=&quot;#random_get.buf&quot; name=&quot;random_get.buf&quot;&gt;&lt;/a&gt; <code>buf</code>: <code>Pointer&lt;u8&gt;</code><br>The buffer to fill with random data.</p>

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -1956,7 +1956,7 @@ Note: This is similar to [`sched_yield`](#sched_yield) in POSIX.
 Write high-quality random data into a buffer.
 This function blocks when the implementation is unable to immediately
 provide sufficient high-quality random data.
-This function may execute slowly, so when large mounts of random data are
+This function may execute slowly, so when large amounts of random data are
 required, it's advisable to use this function to seed a pseudo-random
 number generator, rather than to provide the random data directly.
 

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -481,7 +481,7 @@
   ;;; Write high-quality random data into a buffer.
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.
-  ;;; This function may execute slowly, so when large mounts of random data are
+  ;;; This function may execute slowly, so when large amounts of random data are
   ;;; required, it's advisable to use this function to seed a pseudo-random
   ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "random_get")


### PR DESCRIPTION
This ports the typo fix from

https://github.com/WebAssembly/WASI/pull/388

into the wasi-random repo, which is where the random APIs are in the
process of moving to.

Co-authored-by: Guy Royse <guy@guyroyse.com>