### PR TITLE
Fix wit formatting.

### DIFF
--- a/wasi-random.wit.md
+++ b/wasi-random.wit.md
@@ -6,7 +6,7 @@ It is intended to be portable at least between Unix-family platforms and
 Windows.
 
 ## `getrandom`
-/// Return `len` random bytes.
 ```wit
+/// Return `len` random bytes.
 getrandom: function(len: u32) -> list<u8>
 ```


### PR DESCRIPTION
The documentation comment goes inside the code block.