### PR TITLE
Add an insecure-random API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ WASI Random is a WASI API for obtaining random data.
 
 ### Goals
 
-The primary goal of WASI Random is to allow users to use WASI programs to
-obtain high-quality low-level random data.
+The primary goals of WASI Random are:
+ - To allow users to use WASI programs to obtain high-quality low-level
+   random data.
+ - To allow source languages to enable DoS protection in their hash-maps
+   in host environments that support it.
 
 ### Non-goals
 
@@ -87,11 +90,11 @@ used for debugging, and not production use.
 
 #### [Use case 1]
 
-[Provide example code snippets and diagrams explaining how the API would be used to solve the given problem]
+TODO: Describe a use case using `getrandom`.
 
 #### [Use case 2]
 
-[etc.]
+TODO: Describe a use case using `insecure-random`.
 
 ### Detailed design discussion
 
@@ -110,14 +113,6 @@ collected sufficient entropy to initialize their CSPRNGs. In these cases,
 this API is designed with the belief that it's better for implementations
 to respond to the problem, rather than to pass the responsibility on to
 applications.
-
-### Should there be a separate "insecure" random API?
-
-It's a good question. I haven't ruled it out, but I'd like to learn more
-about use cases where it would be meaningfully better than just using the
-regular random API for everything. In particular, I'm interested in not
-just the application, but also the settings in which the application would
-be used where this would be relevant.
 
 ### What should happen on host platforms with weak or broken randomness APIs?
 
@@ -155,6 +150,11 @@ security. However, many host platforms' CSPRNG APIs do not currently document
 their bits of security, and it doesn't seem desirable to require wasm engines to
 run their own CSPRNG on a platform which alreay has one, so for now, the API
 does not specify a specific number.
+
+### Why is insecure-random a fixed-length value import?
+
+This limits the amount of data that can be obtained through it. Since it's
+insecure, it's not intended to be used as an alternative to `getrandom`.
 
 ### Considered alternatives
 

--- a/wasi-random.wit.md
+++ b/wasi-random.wit.md
@@ -8,5 +8,27 @@ Windows.
 ## `getrandom`
 ```wit
 /// Return `len` random bytes.
+///
+/// This function must produce data from an adaquately seeded CSPRNG, so it
+/// must not block, and the returned data is always unpredictable.
+///
+/// Deterministic environments must omit this function, rather than
+/// implementing it with deterministic data.
 getrandom: function(len: u32) -> list<u8>
+```
+
+## `insecure-random`
+```wit
+/// A value containing 128 random bits.
+///
+/// This is a value import, which means it only provides one value, rather
+/// than being a function that could be called multiple times. This is intented
+/// to be used by source languages to initialize hash-maps without needing the
+/// full `getrandom` API.
+///
+/// This value is not required to be computed from a CSPRNG, and may even be
+/// entirely deterministic. Host implementatations are encouraged to provide
+/// random values to any program exposed to attacker-controlled content, to
+/// enable DoS protection built into many languages' hash-map implementations.
+insecure-random: tuple<u64, u64>
 ```


### PR DESCRIPTION
This API uses a value import, so it limits the amount of data that can
be obtained. This is hopefully enough data to allow source languages to
initialize their DoS-resistant hash-maps, but limited so as not to be
a `getrandom` alternative.

Also, add some more documentation.