### PR TITLE
Update to the latest wit-bindgen syntax.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: WebAssembly/wit-abi-up-to-date@v2
+    - uses: WebAssembly/wit-abi-up-to-date@v5
       with:
-        wit-abi-tag: wit-abi-0.1.0
+        wit-abi-tag: wit-abi-0.4.0

--- a/wasi-random.abi.md
+++ b/wasi-random.abi.md
@@ -5,10 +5,16 @@
 #### <a href="#getrandom" name="getrandom"></a> `getrandom` 
 
   Return `len` random bytes.
+  
+  This function must produce data from an adaquately seeded CSPRNG, so it
+  must not block, and the returned data is always unpredictable.
+  
+  Deterministic environments must omit this function, rather than
+  implementing it with deterministic data.
 ##### Params
 
 - <a href="#getrandom.len" name="getrandom.len"></a> `len`: `u32`
-##### Results
+##### Result
 
-- <a href="#getrandom." name="getrandom."></a> ``: list<`u8`>
+- list<`u8`>
 

--- a/wasi-random.wit.md
+++ b/wasi-random.wit.md
@@ -14,7 +14,7 @@ Windows.
 ///
 /// Deterministic environments must omit this function, rather than
 /// implementing it with deterministic data.
-getrandom: function(len: u32) -> list<u8>
+getrandom: func(len: u32) -> list<u8>
 ```
 
 ## `insecure-random`


### PR DESCRIPTION
For wasi-random, this is just `function` -> `func`.