### PR TITLE
Add a `get-random-u64` function.

### DIFF
--- a/wasi-random.abi.md
+++ b/wasi-random.abi.md
@@ -2,7 +2,7 @@
 
 ----
 
-#### <a href="#getrandom" name="getrandom"></a> `getrandom` 
+#### <a href="#get_random_bytes" name="get_random_bytes"></a> `get-random-bytes` 
 
   Return `len` random bytes.
   
@@ -13,8 +13,23 @@
   implementing it with deterministic data.
 ##### Params
 
-- <a href="#getrandom.len" name="getrandom.len"></a> `len`: `u32`
+- <a href="#get_random_bytes.len" name="get_random_bytes.len"></a> `len`: `u32`
 ##### Results
 
 - list<`u8`>
+
+----
+
+#### <a href="#get_random_u64" name="get_random_u64"></a> `get-random-u64` 
+
+  Return a random `u64` value.
+  
+  This function must produce data from an adaquately seeded CSPRNG, so it
+  must not block, and the returned data is always unpredictable.
+  
+  Deterministic environments must omit this function, rather than
+  implementing it with deterministic data.
+##### Results
+
+- `u64`
 

--- a/wasi-random.wit.md
+++ b/wasi-random.wit.md
@@ -5,7 +5,7 @@ WASI Random is a random data API.
 It is intended to be portable at least between Unix-family platforms and
 Windows.
 
-## `getrandom`
+## `get-random-bytes`
 ```wit
 /// Return `len` random bytes.
 ///
@@ -14,7 +14,19 @@ Windows.
 ///
 /// Deterministic environments must omit this function, rather than
 /// implementing it with deterministic data.
-getrandom: func(len: u32) -> list<u8>
+get-random-bytes: func(len: u32) -> list<u8>
+```
+
+## `get-random-u64`
+```wit
+/// Return a random `u64` value.
+///
+/// This function must produce data from an adaquately seeded CSPRNG, so it
+/// must not block, and the returned data is always unpredictable.
+///
+/// Deterministic environments must omit this function, rather than
+/// implementing it with deterministic data.
+get-random-u64: func() -> u64
 ```
 
 ## `insecure-random`


### PR DESCRIPTION
Rename `getrandom` to `get-random-bytes` and add a `get-random-u64` function. It returns the same kind of random data, just in a different format. A `u64` is more convenient for some use cases, and in this time when returning a `list<u8>` may incur an allocation, returning a `u64` avoids that overhead.

Thanks to @npmccallum for suggesting this!