### PR TITLE
wit syntax: use semicolons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: WebAssembly/wit-abi-up-to-date@v15
+    - uses: WebAssembly/wit-abi-up-to-date@v16

--- a/wit/insecure-seed.wit
+++ b/wit/insecure-seed.wit
@@ -20,5 +20,5 @@ interface insecure-seed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
-    insecure-seed: func() -> tuple<u64, u64>
+    insecure-seed: func() -> tuple<u64, u64>;
 }

--- a/wit/insecure.wit
+++ b/wit/insecure.wit
@@ -11,11 +11,11 @@ interface insecure {
     /// There are no requirements on the values of the returned bytes, however
     /// implementations are encouraged to return evenly distributed values with
     /// a long period.
-    get-insecure-random-bytes: func(len: u64) -> list<u8>
+    get-insecure-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return an insecure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
-    get-insecure-random-u64: func() -> u64
+    get-insecure-random-u64: func() -> u64;
 }

--- a/wit/random.wit
+++ b/wit/random.wit
@@ -15,11 +15,11 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
-    get-random-bytes: func(len: u64) -> list<u8>
+    get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
-    get-random-u64: func() -> u64
+    get-random-u64: func() -> u64;
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,7 +1,7 @@
-package wasi:random
+package wasi:random;
 
 world imports {
-    import random
-    import insecure
-    import insecure-seed
+    import random;
+    import insecure;
+    import insecure-seed;
 }


### PR DESCRIPTION
Adopt semicolons in the wits, and update CI to require them.