### PR TITLE
Add `get-*` prefix

### DIFF
--- a/wit-0.3.0-draft/insecure-seed.wit
+++ b/wit-0.3.0-draft/insecure-seed.wit
@@ -23,5 +23,5 @@ interface insecure-seed {
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
     @since(version = 0.3.0)
-    insecure-seed: func() -> tuple<u64, u64>;
+    get-insecure-seed: func() -> tuple<u64, u64>;
 }


### PR DESCRIPTION
As proposed in a [previous WASI meeting](https://docs.google.com/presentation/d/1on-QuMkOQ-2GCFcJG0DulxKIEDN4KrxveD--gFIzWyQ/edit?usp=sharing), this PR prefixes property-like methods with `get-`.
