### PR TITLE
ci: lint and publish 0.3.0 timestamp based rc's

### DIFF
--- a/.github/workflows/ci-0.3.yml
+++ b/.github/workflows/ci-0.3.yml
@@ -1,0 +1,33 @@
+name: Validate 0.3.0 WIT Definitions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wit-0.3.0-draft/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'wit-0.3.0-draft/**'
+
+jobs:
+  abi-up-to-date:
+    name: Check 0.3.0 ABI files are up-to-date
+    runs-on: ubuntu-latest
+    steps:
+    # v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    
+    - name: Install wit-deps
+      run: |
+        curl -Lo 'wit-deps' https://github.com/bytecodealliance/wit-deps/releases/download/v0.3.5/wit-deps-x86_64-unknown-linux-musl
+        chmod +x wit-deps
+    
+    - name: Ensure wit-0.3.0-draft files are valid
+      run: ../wit-deps check
+      working-directory: wit-0.3.0-draft
+      
+    - uses: WebAssembly/wit-abi-up-to-date@v24
+      with:
+        all-features: 'true'
+        directory: 'wit-0.3.0-draft'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,16 +2,21 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'wit-0.3.0-draft/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'wit-0.3.0-draft/**'
 
 jobs:
   abi-up-to-date:
     name: Check ABI files are up-to-date
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: WebAssembly/wit-abi-up-to-date@v23
+    # v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: WebAssembly/wit-abi-up-to-date@v24
       with:
         wit-bindgen: '0.37.0'
         all-features: 'true'

--- a/.github/workflows/publish-0.3.yml
+++ b/.github/workflows/publish-0.3.yml
@@ -1,0 +1,76 @@
+name: Publish 0.3.0 WIT Definitions
+
+on:
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: write
+
+    steps:
+      # Checkout the repo and install dependencies
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
+        
+      - name: Install wkg
+        shell: bash
+        run: cargo binstall wkg
+        
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Set version with collision handling
+        id: version
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          BASE_VERSION="v0.3.0-rc-${DATE}"
+          COUNTER=1
+          VERSION="${BASE_VERSION}"
+          
+          # Check if the tag already exists
+          while git ls-remote --tags origin | grep -q "refs/tags/${VERSION}$"; do
+            VERSION="${BASE_VERSION}-${COUNTER}"
+            COUNTER=$((COUNTER + 1))
+          done
+          
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag the commit with version
+        run: |
+          git tag "${{ steps.version.outputs.value }}"
+          git push origin "${{ steps.version.outputs.value }}"
+
+      - name: Login to the GitHub registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_PAT }}
+      
+      - name: Build
+        shell: bash
+        run: wkg wit build -o "random-0.3.0.wasm" --wit-dir wit-0.3.0-draft
+
+      # Upload the Wasm binary to the GitHub registry
+      - name: Publish to GitHub Container Registry
+        id: publish
+        uses: bytecodealliance/wkg-github-action@v5
+        with:
+            oci-reference-without-tag: "ghcr.io/webassembly/wasi/random"
+            file: "random-0.3.0.wasm"
+            description: "A WASI API for obtaining pseudo-random data."
+            source: 'https://github.com/webassembly/wasi'
+            homepage: 'https://wasi.dev'
+            version: ${{ steps.version.outputs.value }}
+            licenses: 'Apache-2.0 WITH LLVM-exception'
+
+      # Sign the output component
+      - name: Sign the wasm component
+        run: cosign sign --yes ghcr.io/webassembly/wasi/random-0.3.0@${{ steps.publish.outputs.digest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish a Wasm Component package to GitHub Artifacts
 on:
   push:
     tags:
-      - v*
+      - v0.2*
   workflow_dispatch:
 
 env:
@@ -23,12 +23,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.10.15
+        uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
       - name: Install wkg
         shell: bash
         run: cargo binstall wkg
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
  
       # To version our image we want to obtain the version from the tag
       - name: Get version
@@ -41,7 +41,7 @@ jobs:
       
       # To upload our image to the GitHub registry, we first have to login
       - name: Login to the GitHub registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       # Checkout the repo and install dependencies
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.10.15
+        uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8 # v1.14.1
       - name: Install wit-bindgen
         shell: bash
         run: cargo binstall wit-bindgen-cli


### PR DESCRIPTION
The publish workflow for 0.3, unlike publish for main, is manually
triggered (vs being triggered by a release). It's easier to turnkey the
timestamp tags this way and the assumption is that we wouldn't want to
trigger "releases" for these while the churn rate is high. This also
aims to avoid creating PR's across repos that would require
manual approval.

Before a tag has been created the version value will be:
```bash
echo $VERSION
v0.3.0-rc-2025-07-22
```

Multiple revs in a single day will produce: v0.3.0-rc-2025-07-22-n
